### PR TITLE
WIP: Fixed Input Swaps

### DIFF
--- a/contracts/OffsetHelper.sol
+++ b/contracts/OffsetHelper.sol
@@ -311,6 +311,11 @@ contract OffsetHelper is OffsetHelperStorage {
             block.timestamp
         );
 
+        // remove remaining approval if less input token was consumed
+        if (amounts[0] < amountIn) {
+            IERC20(_fromToken).approve(sushiRouterAddress, 0);
+        }
+
         // update balances
         balances[msg.sender][_toToken] += _toAmount;
     }


### PR DESCRIPTION
As discussed with @lazaralex98 in private conversation, this PR adds support for fixed-input swaps.

The current `OffsetHelper` only supports specifying a fixed amount of Toucan offset token, which makes sense in cases where users want to achieve a fixed, specific CO2 offset. However, there are situations where a users (or smart contract) wants to send a fixed amount of MATIC, USDC or other token and just have it all swapped to NCT to then retire the resulting TCO2s.

This PR extends the `OffsetHelper` contract by several new public functions that allow for fixed-input swapping. This happens in a backwards-compatible way -- existing functions stay the same. Some refactors were done for code deduplication.

This PR is being completed in the context of a grant that Yieldgate receives from Toucan for our project **Stake For Earth**, which needs this functionality 🌍 💚 