### PR TITLE
fix: prevent retiring TCO2s with amount of 0 (new)

### DIFF
--- a/contracts/OffsetHelper.sol
+++ b/contracts/OffsetHelper.sol
@@ -642,6 +642,12 @@ contract OffsetHelper is OffsetHelperStorage {
 
         uint256 i = 0;
         while (i < tco2sLen) {
+            if (_amounts[i] == 0) {
+                unchecked {
+                    i++;
+                }
+                continue;
+            }
             require(
                 balances[msg.sender][_tco2s[i]] >= _amounts[i],
                 "Insufficient TCO2 balance"


### PR DESCRIPTION
Without such prevention, `autoRetire` will attempt to retire TCO2s with an amount of 0. This results in a reverted transaction. This is especially relevant for NCT retirements since the first TCO2 in its array has an amount of 0.

To prevent 0 amount TCO2 retirement attempts, an if check is added. If `true` it will skip the current loop iteration.